### PR TITLE
Support Loading only Specified Playlist Manifests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.3",
       "license": "MIT",
       "dependencies": {
-        "@eyevinn/m3u8": "^0.5.3",
+        "@eyevinn/m3u8": "^0.5.6",
         "request": "^2.88.2"
       },
       "devDependencies": {
@@ -336,9 +336,9 @@
       }
     },
     "node_modules/@eyevinn/m3u8": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@eyevinn/m3u8/-/m3u8-0.5.3.tgz",
-      "integrity": "sha512-FdkC95+R5X7YvJmGsmxRTOwc9mRy5BRVZOz6vVosSoK2AILWZMnox/AuTEqS3dbt1r5lnrnHbKSrNHSqtAodrg==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@eyevinn/m3u8/-/m3u8-0.5.6.tgz",
+      "integrity": "sha512-aYWN9Rzofs3MCuoGrJww6vExnKg8bLHN2jAmzjK8t/akwT3bzwR3i2kqH895ZysR87mikgOzF3IaBp4OYYfwWg==",
       "dependencies": {
         "chunked-stream": "~0.0.2"
       }
@@ -2493,9 +2493,9 @@
       }
     },
     "@eyevinn/m3u8": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@eyevinn/m3u8/-/m3u8-0.5.3.tgz",
-      "integrity": "sha512-FdkC95+R5X7YvJmGsmxRTOwc9mRy5BRVZOz6vVosSoK2AILWZMnox/AuTEqS3dbt1r5lnrnHbKSrNHSqtAodrg==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@eyevinn/m3u8/-/m3u8-0.5.6.tgz",
+      "integrity": "sha512-aYWN9Rzofs3MCuoGrJww6vExnKg8bLHN2jAmzjK8t/akwT3bzwR3i2kqH895ZysR87mikgOzF3IaBp4OYYfwWg==",
       "requires": {
         "chunked-stream": "~0.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/Eyevinn/hls-splice",
   "main": "index.js",
   "scripts": {
-    "test": "$(npm bin)/jasmine",
+    "test": "jasmine",
     "postversion": "git push && git push --tags",
     "coverage": "nyc npm test && nyc report",
     "coveralls": "nyc npm test && nyc report --reporter=text-lcov | coveralls"
@@ -26,7 +26,7 @@
     "nyc": "^15.0.1"
   },
   "dependencies": {
-    "@eyevinn/m3u8": "^0.5.3",
+    "@eyevinn/m3u8": "^0.5.6",
     "request": "^2.88.2"
   }
 }

--- a/spec/integration_tests_spec.js
+++ b/spec/integration_tests_spec.js
@@ -39,4 +39,49 @@ describe("HLSSpliceVod", () => {
       done();
     })
   });
+
+  
+  it("can insert ads in an HLS VOD with seperate Manifest Loaders (Master + Media)", done => {
+    const hlsVod = new HLSSpliceVod('https://vod.streaming.a2d.tv/948a9dc4-ccb6-4de0-8295-40909bc90e43/c70657d0-5fe3-11ed-9d66-430eb269fe23_20331478.ism/.m3u8',
+    {
+      absoluteUrls: true
+    });
+    hlsVod.loadMasterManifest().then(() => {
+      hlsVod.loadMediaManifest("https://vod.streaming.a2d.tv/948a9dc4-ccb6-4de0-8295-40909bc90e43/c70657d0-5fe3-11ed-9d66-430eb269fe23_20331478.ism/c70657d0-5fe3-11ed-9d66-430eb269fe23_20331478-video=300000.m3u8", 455000)
+    })
+    .then(() => {
+      return hlsVod.insertAdAt(0, 'https://ovpuspvod.a2d-stage.tv/trailers/63ef9c36e3ffa90028603374/output.ism/.m3u8');
+    })
+    .then(() => {
+      const mediaManifest = hlsVod.getMediaManifest(455000);
+      const lines = mediaManifest.split("\n");
+      expect(lines[8]).toEqual(`#EXT-X-MAP:URI="https://ovpuspvod.a2d-stage.tv/trailers/63ef9c36e3ffa90028603374/output.ism/hls/output-video=300000.m4s"`);
+      expect(lines[12]).toEqual(`https://ovpuspvod.a2d-stage.tv/trailers/63ef9c36e3ffa90028603374/output.ism/hls/output-video=300000-1.m4s`);
+      expect(lines[23]).toEqual(`#EXT-X-MAP:URI="https://vod.streaming.a2d.tv/948a9dc4-ccb6-4de0-8295-40909bc90e43/c70657d0-5fe3-11ed-9d66-430eb269fe23_20331478.ism/hls/c70657d0-5fe3-11ed-9d66-430eb269fe23_20331478-video=300000.m4s"`);
+      expect(lines[28]).toEqual(`https://vod.streaming.a2d.tv/948a9dc4-ccb6-4de0-8295-40909bc90e43/c70657d0-5fe3-11ed-9d66-430eb269fe23_20331478.ism/hls/c70657d0-5fe3-11ed-9d66-430eb269fe23_20331478-video=300000-1.m4s`);
+      done();
+    })
+  });
+
+  it("can insert ads in an HLS VOD with seperate Manifest Loaders (Master + Audio)", done => {
+    const hlsVod = new HLSSpliceVod('https://vod.streaming.a2d.tv/948a9dc4-ccb6-4de0-8295-40909bc90e43/c70657d0-5fe3-11ed-9d66-430eb269fe23_20331478.ism/.m3u8',
+    {
+      absoluteUrls: true
+    });
+    hlsVod.loadMasterManifest().then(() => {
+      hlsVod.loadAudioManifest("https://vod.streaming.a2d.tv/948a9dc4-ccb6-4de0-8295-40909bc90e43/c70657d0-5fe3-11ed-9d66-430eb269fe23_20331478.ism/c70657d0-5fe3-11ed-9d66-430eb269fe23_20331478-audio=128000.m3u8", "audio-aacl-128", "audio")
+    })
+    .then(() => {
+      return hlsVod.insertAdAt(0, 'https://ovpuspvod.a2d-stage.tv/trailers/63ef9c36e3ffa90028603374/output.ism/.m3u8');
+    })
+    .then(() => {
+      const audioManifest = hlsVod.getAudioManifest("audio-aacl-128", "audio");
+      const lines = audioManifest.split("\n");
+      expect(lines[8]).toEqual(`#EXT-X-MAP:URI="https://ovpuspvod.a2d-stage.tv/trailers/63ef9c36e3ffa90028603374/output.ism/hls/output-audio=128000.m4s"`);
+      expect(lines[12]).toEqual(`https://ovpuspvod.a2d-stage.tv/trailers/63ef9c36e3ffa90028603374/output.ism/hls/output-audio=128000-1.m4s`);
+      expect(lines[23]).toEqual(`#EXT-X-MAP:URI="https://vod.streaming.a2d.tv/948a9dc4-ccb6-4de0-8295-40909bc90e43/c70657d0-5fe3-11ed-9d66-430eb269fe23_20331478.ism/hls/c70657d0-5fe3-11ed-9d66-430eb269fe23_20331478-audio=128000.m4s"`);
+      expect(lines[28]).toEqual(`https://vod.streaming.a2d.tv/948a9dc4-ccb6-4de0-8295-40909bc90e43/c70657d0-5fe3-11ed-9d66-430eb269fe23_20331478.ism/hls/c70657d0-5fe3-11ed-9d66-430eb269fe23_20331478-audio=128000-1.m4s`);
+      done();
+    })
+  });
 });


### PR DESCRIPTION
In addition to the `load()` fn which loads all available video and audio playlist manifests, plus the master manifest. To support the option of loading each variant and master manifest individually, a new fn `loadMasterManifest()` has been added.
Furthermore, `loadMediaManifest()` and `loadAudioManifest` have become public methods

The hope is to give an option where you can reduce the number of m3u8 fetches needed inorder to get one specific spliced playlist manifest.