### PR TITLE
fix: make the startdate on the interstitial tag more accurate

### DIFF
--- a/index.js
+++ b/index.js
@@ -526,7 +526,7 @@ class HLSSpliceVod {
     }
   }
 
-  insertInterstitialAt(offset, id, uri, isAssetList, timeoffset, opts={
+  insertInterstitialAt(offset, id, uri, isAssetList, opts={
     resumeOffset: undefined,
     playoutLimit: undefined,
     snap: undefined,
@@ -536,6 +536,8 @@ class HLSSpliceVod {
     timelinestyle: undefined,
     custombeacon: undefined,
     cue: undefined,
+    previousBreakDuration: 0,
+    addDeltaOffset: false,
   }) {
 
     return new Promise((resolve, reject) => {
@@ -544,8 +546,11 @@ class HLSSpliceVod {
       }
       let startDate;
       let extraAttrs = "";
+      let prevBreakOffset = 0;
       if (opts) {
-
+        if (opts.previousBreakDuration) {
+          prevBreakOffset = opts.previousBreakDuration;
+        }
         if (opts.cue) {
           const cueValue = _parseValidCueValues(opts.cue);
           if (cueValue) {
@@ -596,20 +601,22 @@ class HLSSpliceVod {
         let i = 0;
         this.playlists[bw].items.PlaylistItem[0].set("date", new Date(1));
         const playlistSize = this.playlists[bw].items.PlaylistItem.length;
-        let segmentDurationAtPos = 0;
         let total_duration = 0;
 
-        while (pos < offset && i < playlistSize) {
+        while (pos <= offset && i < playlistSize) {
           const plItem = this.playlists[bw].items.PlaylistItem[i];
           total_duration = total_duration + plItem.get("duration");
           pos += plItem.get("duration") * 1000;
           if (pos <= offset) {
             i++;
-            segmentDurationAtPos = plItem.get("duration") * 1000;
           }
         }
-        const deltaOffest = pos - offset; // delta between actual offset and the target offset
-        const dateInMs = 1 + Number(offset) + timeoffset + segmentDurationAtPos - deltaOffest;
+        let dateInMs = 1 + Number(offset) + prevBreakOffset;
+        if (opts && opts.addDeltaOffset) {
+          // delta between actual offset and the target offset
+          dateInMs += (pos - offset);
+        }
+        dateInMs = dateInMs < 0 ? 1 : dateInMs;
         startDate = new Date(dateInMs).toISOString();
 
         let durationTag = "";

--- a/spec/hls_splice_spec.js
+++ b/spec/hls_splice_spec.js
@@ -1460,18 +1460,18 @@ describe("HLSSpliceVod with Demuxed Audio Tracks,", () => {
     mockVod
       .load(mockMasterManifest, mockMediaManifest, mockAudioManifest)
       .then(() => {
-        return mockVod.insertInterstitialAt(16000, "001", "/assetlist/sdfsdfjlsdfsdf", true);
+        return mockVod.insertInterstitialAt(16000, "001", "/assetlist/sdfsdfjlsdfsdf", true, { addDeltaOffset: true });
       })
       .then(() => {
         const m3u8 = mockVod.getMediaManifest(4497000);
         let lines = m3u8.split("\n");
         expect(lines[10]).toEqual(
-          '#EXT-X-DATERANGE:ID="001",CLASS="com.apple.hls.interstitial",START-DATE="1970-01-01T00:00:16.001Z",X-ASSET-LIST="/assetlist/sdfsdfjlsdfsdf"'
+          '#EXT-X-DATERANGE:ID="001",CLASS="com.apple.hls.interstitial",START-DATE="1970-01-01T00:00:18.001Z",X-ASSET-LIST="/assetlist/sdfsdfjlsdfsdf"'
         );
         const m3u8Audio = mockVod.getAudioManifest("stereo", "sv");
         lines = m3u8Audio.split("\n");
         expect(lines[10]).toEqual(
-          '#EXT-X-DATERANGE:ID="001",CLASS="com.apple.hls.interstitial",START-DATE="1970-01-01T00:00:16.001Z",X-ASSET-LIST="/assetlist/sdfsdfjlsdfsdf"'
+          '#EXT-X-DATERANGE:ID="001",CLASS="com.apple.hls.interstitial",START-DATE="1970-01-01T00:00:18.001Z",X-ASSET-LIST="/assetlist/sdfsdfjlsdfsdf"'
         );
         done();
       });


### PR DESCRIPTION
When using HLS with interstitials and the segment's durations do not line up perfectly with the desired offset, eg. you want to insert interstitials at position 16s but the HLS playlist only consists of 10s segments.

This PR adds an option to adjust the interstitial start-date having it line up with the date-time of the next segment, in case the desired position would be in the middle of said segment. 
